### PR TITLE
Add unit declarator to module and class declarations

### DIFF
--- a/lib/Net/Packet.pm6
+++ b/lib/Net/Packet.pm6
@@ -57,7 +57,7 @@ exports:
 
 =head2 module Net::Packet
 
-module Net::Packet;
+unit module Net::Packet;
 
 =head3 Subroutines
 

--- a/lib/Net/Packet/Base.pm6
+++ b/lib/Net/Packet/Base.pm6
@@ -1,4 +1,4 @@
-class Net::Packet::Base;
+unit class Net::Packet::Base;
 
 my constant Base is export(:short) ::= Net::Packet::Base;
 

--- a/lib/Net/Packet/EtherType.pm6
+++ b/lib/Net/Packet/EtherType.pm6
@@ -18,7 +18,7 @@ Net::Packet::EtherType - Enumerator to describe EtherType.
 
 =head2 enum Net::Packet::EtherType
 
-module Net::Packet::EtherType;
+unit module Net::Packet::EtherType;
 
 enum Net::Packet::EtherType (
     IPv4             => 0x0800,

--- a/lib/Net/Packet/Ethernet.pm6
+++ b/lib/Net/Packet/Ethernet.pm6
@@ -43,7 +43,7 @@ The byte buffer can be of the builtin Buf type or the C_Buf type of Net::Pcap.
 is Net::Packet::Base;
 =end code
 
-class Net::Packet::Ethernet is Base;
+unit class Net::Packet::Ethernet is Base;
 
 my constant Ethernet  is export(:short) ::= Net::Packet::Ethernet;
 my constant MAC_addr  is export(:short) ::= Net::Packet::MAC_addr;

--- a/lib/Net/Packet/ICMP.pm6
+++ b/lib/Net/Packet/ICMP.pm6
@@ -31,7 +31,7 @@ Net::Packet::ICMP
 is Net::Packet::Base
 =end code
 
-class Net::Packet::ICMP is Base;
+unit class Net::Packet::ICMP is Base;
 
 my constant ICMP is export(:short) ::= Net::Packet::ICMP;
 

--- a/lib/Net/Packet/IP_proto.pm6
+++ b/lib/Net/Packet/IP_proto.pm6
@@ -26,7 +26,7 @@ Net::Packet::IP_proto
 
 =head2 enum Net::Packet::IP_proto
 
-module Net::Packet::IP_proto;
+unit module Net::Packet::IP_proto;
 
 enum Net::Packet::IP_proto (
     ICMP => 0x01,

--- a/lib/Net/Packet/IPv4.pm6
+++ b/lib/Net/Packet/IPv4.pm6
@@ -38,7 +38,7 @@ The byte buffer can be of the builtin Buf type or the C_Buf type of Net::Pcap.
 is Net::Packet::Base
 =end code
     
-class Net::Packet::IPv4 is Net::Packet::Base;
+unit class Net::Packet::IPv4 is Net::Packet::Base;
     
 my constant IPv4 is export(:short) ::= Net::Packet::IPv4;
 my constant IPv4_addr is export(:short) ::= Net::Packet::IPv4_addr;

--- a/lib/Net/Packet/IPv4_addr.pm6
+++ b/lib/Net/Packet/IPv4_addr.pm6
@@ -25,7 +25,7 @@ Net::Packet::IPv4_addr
 
 =head2 class Net::Packet::IPv4_addr
 
-class Net::Packet::IPv4_addr;
+unit class Net::Packet::IPv4_addr;
 
 my constant IPv4_addr is export(:short) ::= Net::Packet::IPv4_addr;
 

--- a/lib/Net/Packet/MAC_addr.pm6
+++ b/lib/Net/Packet/MAC_addr.pm6
@@ -26,7 +26,7 @@ Net::Packet::MAC_addr - Decode and format MAC addresses.
 
 =head2 class Net::Packet::MAC_addr
 
-class Net::Packet::MAC_addr;
+unit class Net::Packet::MAC_addr;
 
 my constant MAC_addr is export(:short) ::= Net::Packet::MAC_addr;
 

--- a/lib/Net/Packet/UDP.pm6
+++ b/lib/Net/Packet/UDP.pm6
@@ -34,7 +34,7 @@ The byte buffer can be of the builtin Buf type or the C_Buf type of Net::Pcap.
 is Net::Packet::Base
 =end code
 
-class Net::Packet::UDP is Net::Packet::Base;
+unit class Net::Packet::UDP is Net::Packet::Base;
 
 my constant UDP is export(:short) ::= Net::Packet::UDP;
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
