### PR TITLE
Fix removed @*INC

### DIFF
--- a/t/ARP.t
+++ b/t/ARP.t
@@ -1,5 +1,5 @@
 use v6;
-BEGIN {@*INC.unshift: './blib/lib' }
+use lib 'blib/lib';
 
 use Test;
 

--- a/t/Ethernet.t
+++ b/t/Ethernet.t
@@ -1,5 +1,5 @@
 use v6;
-BEGIN {@*INC.unshift: './blib/lib' }
+use lib 'blib/lib';
 
 use Test;
 

--- a/t/ICMP.t
+++ b/t/ICMP.t
@@ -1,5 +1,5 @@
 use v6;
-BEGIN { @*INC.unshift: 'blib/lib' }
+use lib 'blib/lib';
 
 use Test;
 

--- a/t/IPv4.t
+++ b/t/IPv4.t
@@ -1,5 +1,5 @@
 use v6;
-BEGIN {@*INC.unshift: './blib/lib'; }
+use lib 'blib/lib';
 
 use Test;
 

--- a/t/UDP.t
+++ b/t/UDP.t
@@ -1,5 +1,5 @@
 use v6;
-BEGIN {@*INC.unshift: './blib/lib' }
+use lib 'blib/lib';
 
 use Test;
 


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.
